### PR TITLE
Correct pointer REPORT_COUNT for the X/Y/Wheel

### DIFF
--- a/TrinketHidCombo/TrinketHidComboC.c
+++ b/TrinketHidCombo/TrinketHidComboC.c
@@ -103,7 +103,7 @@ const PROGMEM char usbHidReportDescriptor[USB_CFG_HID_REPORT_DESCRIPTOR_LENGTH] 
 	0x15, 0x81,           //     LOGICAL_MINIMUM (-127)
 	0x25, 0x7F,           //     LOGICAL_MAXIMUM (127)
 	0x75, 0x08,           //     REPORT_SIZE (8)
-	0x95, 0x02,           //     REPORT_COUNT (2)
+	0x95, 0x03,           //     REPORT_COUNT (3)
 	0x81, 0x06,           //     INPUT (Data,Var,Rel)
 	0xC0,                 //   END_COLLECTION
 	0xC0,                 // END COLLECTION


### PR DESCRIPTION
The Pointer REPORT_COUNT field needs to be 3 due to the addition of the 'Wheel' field. Without it, Linux (4.2.0-34, at least) doesn't recognize wheel-only reports.
